### PR TITLE
fix(rails/locale): add missing one key for user model in ja.yml

### DIFF
--- a/rails/locales/ja.yml
+++ b/rails/locales/ja.yml
@@ -27,6 +27,7 @@ ja:
         updated_at: 更新日
     models:
       user:
+        one: ユーザー
         other: ユーザー
   devise:
     confirmations:


### PR DESCRIPTION
because of our test is failling with following error:
```
     I18n::InvalidPluralizationData:
       translation data {:other=>"ユーザー"} can not be used with :count => 1. key 'one' is missing.
```