### PR TITLE
require 'rails_i18n' in railtie.rb

### DIFF
--- a/lib/devise-i18n/railtie.rb
+++ b/lib/devise-i18n/railtie.rb
@@ -1,5 +1,6 @@
 require 'rails'
 require 'devise-i18n/view_helpers'
+require 'rails_i18n'
 
 module DeviseI18n
   class Engine < ::Rails::Engine

--- a/spec/support/devise_i18n_views_app.rb
+++ b/spec/support/devise_i18n_views_app.rb
@@ -2,7 +2,6 @@ require "action_controller/railtie"
 require "active_model"
 require 'omniauth-twitter'
 require 'devise-i18n'
-require 'rails_i18n'
 
 class User
   def email


### PR DESCRIPTION
Fix: https://github.com/devise-i18n/devise-i18n/issues/28

With this PR, rails_i18n is always required in railtie.rb. rails_i18n will include `I18n::Backend::Pluralization` into `I18n.Backend.class`. This module will solve the problem reported in https://github.com/devise-i18n/devise-i18n/issues/28 .